### PR TITLE
Add client and reporter tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
+  // Include tests in __tests__ folders in addition to *.test.ts files
+  testMatch: ['**/*.test.ts', '**/__tests__/**/*.ts'],
 };

--- a/src/client/__tests__/ConfigLoader.test.ts
+++ b/src/client/__tests__/ConfigLoader.test.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ConfigLoader, DEFAULT_CONFIG_FILENAME } from '../ConfigLoader';
+import { MCPClient } from '../MCPClient';
+
+/** Helper to create a temporary configuration file */
+function createTempConfig(servers: Record<string, any>): { dir: string; path: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-config-'));
+  const configPath = path.join(dir, 'config.json');
+  const config = {
+    numTestsPerTool: 1,
+    timeoutMs: 100,
+    outputFormat: 'console',
+    verbose: false,
+    mcpServers: servers
+  };
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  return { dir, path: configPath };
+}
+
+describe('ConfigLoader', () => {
+  test('creates and loads default config', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-default-'));
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+
+    const loader = new ConfigLoader();
+    const createdPath = loader.createDefaultConfigIfNeeded();
+    expect(createdPath).toBe(path.join(tempDir, DEFAULT_CONFIG_FILENAME));
+    expect(fs.existsSync(createdPath!)).toBe(true);
+
+    const config = loader.loadConfig();
+    expect(config).not.toBeNull();
+    expect(loader.getServerNames().length).toBeGreaterThan(0);
+
+    process.chdir(originalCwd);
+  });
+});
+
+describe('MCPClient', () => {
+  test('lists configured servers', () => {
+    const { path: configPath } = createTempConfig({
+      first: { command: 'node', args: ['first.js'], env: {} },
+      second: { command: 'node', args: ['second.js'], env: {} }
+    });
+
+    const client = new MCPClient();
+    // load configuration without connecting to any server
+    (client as any).configLoader.loadConfig(configPath);
+    const servers = client.listConfiguredServers();
+    expect(servers).toEqual(['first', 'second']);
+  });
+});

--- a/src/reporter/__tests__/Reporter.test.ts
+++ b/src/reporter/__tests__/Reporter.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Reporter } from '../Reporter';
+import { TestResult, TesterConfig } from '../../types';
+
+function createTestResult(passed: boolean): TestResult {
+  return {
+    testCase: {
+      id: '1',
+      toolName: 'tool',
+      description: 'desc',
+      naturalLanguageQuery: 'query',
+      inputs: {},
+      expectedOutcome: { status: passed ? 'success' : 'error' }
+    },
+    passed,
+    executionTime: 5,
+    validationErrors: passed ? [] : ['err']
+  };
+}
+
+describe('Reporter', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-'));
+  });
+
+  test('creates JSON report', async () => {
+    const reporter = new Reporter();
+    const results = [createTestResult(true)];
+    const config: TesterConfig = {
+      numTestsPerTool: 1,
+      timeoutMs: 100,
+      outputFormat: 'json',
+      outputPath: path.join(tmpDir, 'report.json'),
+      verbose: false
+    };
+
+    await reporter.generateReport(results, config);
+
+    expect(fs.existsSync(config.outputPath!)).toBe(true);
+    const data = JSON.parse(fs.readFileSync(config.outputPath!, 'utf8'));
+    expect(data.summary.totalTests).toBe(1);
+    expect(data.results[0].passed).toBe(true);
+  });
+
+  test('creates HTML report', async () => {
+    const reporter = new Reporter();
+    const results = [createTestResult(false)];
+    const config: TesterConfig = {
+      numTestsPerTool: 1,
+      timeoutMs: 100,
+      outputFormat: 'html',
+      outputPath: path.join(tmpDir, 'report.html'),
+      verbose: false
+    };
+
+    await reporter.generateReport(results, config);
+
+    expect(fs.existsSync(config.outputPath!)).toBe(true);
+    const html = fs.readFileSync(config.outputPath!, 'utf8');
+    expect(html).toContain('<html>');
+    expect(html).toContain('MCP Server Test Report');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ConfigLoader and MCPClient listing servers
- add tests for Reporter JSON and HTML output
- support `__tests__` folders in Jest config

## Testing
- `npm test` *(fails: jest not found)*