### PR TITLE
Add equals and arrayLength validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ Each test case includes:
 - Input parameters
 - Expected outcome criteria
 
+### Validation Rule Types
+
+Validation rules are used to check the structure and content of a tool response.
+The following rule types are supported:
+
+- `contains` – ensure a string or array contains a given value
+- `matches` – check equality or a regular expression match
+- `hasProperty` – verify that a property exists
+- `equals` – assert that a value exactly matches the expected value
+- `arrayLength` – require an array to have a specific length
+- `custom` – invoke a user-defined validation function
+
 ## Test Execution and Validation
 
 For each server specified in the configuration (or all servers if none specified):

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,13 @@ export interface TestCase {
  * Rules for validating the content of a tool response
  */
 export interface ValidationRule {
-  type: 'contains' | 'matches' | 'hasProperty' | 'custom';
+  type:
+    | 'contains'
+    | 'matches'
+    | 'hasProperty'
+    | 'equals'
+    | 'arrayLength'
+    | 'custom';
   target?: string;
   value?: any;
   custom?: (response: any) => boolean;

--- a/src/validator/ResponseValidator.test.ts
+++ b/src/validator/ResponseValidator.test.ts
@@ -76,4 +76,44 @@ describe('ResponseValidator', () => {
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toMatch('Expected tool to return an error');
   });
+
+  test('validates equals rule', () => {
+    const testCase: TestCase = {
+      id: '2',
+      toolName: 'test',
+      description: 'desc',
+      naturalLanguageQuery: '',
+      inputs: {},
+      expectedOutcome: {
+        status: 'success',
+        validationRules: [
+          { type: 'equals', target: 'foo', value: 42, message: 'foo should equal 42' }
+        ]
+      }
+    };
+
+    const response: ToolResponse = { status: 'success', data: { foo: 42 } };
+    const result = validator.validateResponse(response, testCase);
+    expect(result.valid).toBe(true);
+  });
+
+  test('validates arrayLength rule', () => {
+    const testCase: TestCase = {
+      id: '3',
+      toolName: 'test',
+      description: 'desc',
+      naturalLanguageQuery: '',
+      inputs: {},
+      expectedOutcome: {
+        status: 'success',
+        validationRules: [
+          { type: 'arrayLength', target: 'items', value: 3, message: 'items length should be 3' }
+        ]
+      }
+    };
+
+    const response: ToolResponse = { status: 'success', data: { items: [1, 2, 3] } };
+    const result = validator.validateResponse(response, testCase);
+    expect(result.valid).toBe(true);
+  });
 });

--- a/src/validator/ResponseValidator.ts
+++ b/src/validator/ResponseValidator.ts
@@ -85,7 +85,19 @@ export class ResponseValidator implements ResponseValidatorInterface {
             errors.push(rule.message);
           }
           break;
-          
+
+        case 'equals':
+          if (!this.validateEquals(data, rule.target, rule.value)) {
+            errors.push(rule.message);
+          }
+          break;
+
+        case 'arrayLength':
+          if (!this.validateArrayLength(data, rule.target, rule.value)) {
+            errors.push(rule.message);
+          }
+          break;
+
         case 'custom':
           if (rule.custom && !rule.custom(data)) {
             errors.push(rule.message);
@@ -176,6 +188,23 @@ export class ResponseValidator implements ResponseValidatorInterface {
     }
     
     return true;
+  }
+
+  /**
+   * Validate that a value equals the expected value
+   */
+  private validateEquals(data: any, target: string, value: any): boolean {
+    const targetValue = this.getValueByPath(data, target);
+    return JSON.stringify(targetValue) === JSON.stringify(value);
+  }
+
+  /**
+   * Validate that an array has the expected length
+   */
+  private validateArrayLength(data: any, target: string, value: number): boolean {
+    const targetValue = this.getValueByPath(data, target);
+    if (!Array.isArray(targetValue)) return false;
+    return targetValue.length === value;
   }
   
   /**


### PR DESCRIPTION
## Summary
- extend `ValidationRule` union to include `equals` and `arrayLength`
- support the new rule types in `ResponseValidator`
- document the complete list of rule types in README
- add unit tests for the new rules

## Testing
- `npm test` *(fails: jest not found)*