### PR TITLE
Fix repository URL in usage message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ Examples:
   # Use custom config file
   mcp-server-tester ./configs/my-mcp-config.json
 
-Learn more: https://github.com/username/mcp-server-tester
+  Learn more: https://github.com/r-huijts/mcp-server-tester
 `);
 }
 


### PR DESCRIPTION
## Summary
- update the README link in `src/index.ts` to the actual repo location

## Testing
- `npm test` *(fails: jest not found)*