### PR TITLE
Add CLI servers override

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,10 @@ MCP Server Tester supports minimal command-line options:
 | `--init` or `-i` | Create a default configuration file |
 | `--list` or `-l` | List all servers defined in your configuration |
 | `--help` or `-h` | Display help information |
+| `--servers` or `-s` | Comma-separated list of servers to test |
 | `[config-path]` | Specify a custom configuration file path |
+
+The `--servers` option overrides the `servers` array in your configuration file.
 
 ## Test Generation Process
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const connectMock = jest.fn();
+const listToolsMock = jest.fn().mockResolvedValue([]);
+const executeMock = jest.fn().mockResolvedValue({ status: 'success', data: {} });
+const disconnectMock = jest.fn();
+
+jest.mock('./client/MCPClient', () => {
+  return {
+    MCPClient: jest.fn().mockImplementation(() => ({
+      connect: connectMock,
+      listTools: listToolsMock,
+      executeTool: executeMock,
+      disconnect: disconnectMock,
+    })),
+  };
+});
+
+jest.mock('./test-generator/TestGenerator', () => ({
+  TestGenerator: jest.fn().mockImplementation(() => ({
+    generateTests: jest.fn().mockResolvedValue([]),
+  }))
+}));
+
+jest.mock('./validator/ResponseValidator', () => ({
+  ResponseValidator: jest.fn().mockImplementation(() => ({
+    validateResponse: jest.fn().mockReturnValue({ valid: true, errors: [] }),
+  }))
+}));
+
+jest.mock('./reporter/Reporter', () => ({
+  Reporter: jest.fn().mockImplementation(() => ({
+    generateReport: jest.fn().mockResolvedValue(undefined),
+  }))
+}));
+
+import { runTests } from './index';
+
+it('uses servers from CLI flag', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-test-'));
+  const configPath = path.join(tmpDir, 'config.json');
+  const config = {
+    servers: ['first', 'second', 'third'],
+    numTestsPerTool: 1,
+    timeoutMs: 100,
+    outputFormat: 'console',
+    verbose: false,
+    mcpServers: {
+      first: { command: 'echo', args: ['1'], env: {} },
+      second: { command: 'echo', args: ['2'], env: {} },
+      third: { command: 'echo', args: ['3'], env: {} },
+    },
+  };
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+  const originalArgv = process.argv;
+  process.argv = ['node', 'mcp-server-tester', configPath, '--servers', 'second,third'];
+  process.env.ANTHROPIC_API_KEY = 'test-key';
+
+  await runTests();
+
+  expect(connectMock).toHaveBeenCalledTimes(2);
+  expect(connectMock.mock.calls.map((c) => c[0])).toEqual(['second', 'third']);
+
+  process.argv = originalArgv;
+});
+


### PR DESCRIPTION
## Summary
- add `--servers` / `-s` CLI option to override servers list
- document new flag in README
- export `runTests` from CLI entry
- unit test for CLI servers flag

## Testing
- `npm test` *(fails: jest not found)*