### PR TITLE
Fix import in MCPClient

### DIFF
--- a/src/client/MCPClient.ts
+++ b/src/client/MCPClient.ts
@@ -1,6 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { ChildProcess } from 'child_process';
 import { ConfigLoader } from './ConfigLoader';
 import { ToolResponse } from '../types';
 


### PR DESCRIPTION
## Summary
- remove unused `ChildProcess` import

## Testing
- `npx tsc` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*