### PR TITLE
Update hasProperty path handling

### DIFF
--- a/src/validator/ResponseValidator.test.ts
+++ b/src/validator/ResponseValidator.test.ts
@@ -146,4 +146,28 @@ describe('ResponseValidator', () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('custom failed');
   });
+
+  test('validate hasProperty with bracket path', () => {
+    const testCase: TestCase = {
+      id: '5',
+      toolName: 'test',
+      description: 'desc',
+      naturalLanguageQuery: '',
+      inputs: {},
+      expectedOutcome: {
+        status: 'success',
+        validationRules: [
+          { type: 'hasProperty', target: 'items[0].id', message: 'missing id' }
+        ]
+      }
+    };
+
+    const response: ToolResponse = {
+      status: 'success',
+      data: { items: [{ id: 1 }, { id: 2 }] }
+    };
+
+    const result = validator.validateResponse(response, testCase);
+    expect(result.valid).toBe(true);
+  });
 });

--- a/src/validator/ResponseValidator.ts
+++ b/src/validator/ResponseValidator.ts
@@ -167,8 +167,9 @@ export class ResponseValidator implements ResponseValidatorInterface {
    */
   private validateHasProperty(data: any, target: string): boolean {
     if (!target) return false;
-    
-    const parts = target.split('.');
+
+    const normalized = target.replace(/\[(\w+)\]/g, '.$1');
+    const parts = normalized.split('.');
     let current = data;
     
     for (const part of parts) {


### PR DESCRIPTION
## Summary
- make `validateHasProperty` handle bracket path notation
- test hasProperty with bracket path

## Testing
- `npm test` *(fails: jest not found)*