### PR TITLE
Add array index path support in validator

### DIFF
--- a/src/validator/ResponseValidator.test.ts
+++ b/src/validator/ResponseValidator.test.ts
@@ -114,8 +114,31 @@ describe('ResponseValidator', () => {
 
     const response: ToolResponse = { status: 'success', data: { items: [1, 2, 3] } };
     const result = validator.validateResponse(response, testCase);
-    expect(result.valid).toBe(true);
-  });
+      expect(result.valid).toBe(true);
+    });
+
+    test('validates hasProperty rule with array index path', () => {
+      const testCase: TestCase = {
+        id: '5',
+        toolName: 'test',
+        description: 'desc',
+        naturalLanguageQuery: '',
+        inputs: {},
+        expectedOutcome: {
+          status: 'success',
+          validationRules: [
+            { type: 'hasProperty', target: 'items[1].name', message: 'missing' }
+          ]
+        }
+      };
+
+      const response: ToolResponse = {
+        status: 'success',
+        data: { items: [{ name: 'first' }, { name: 'second' }] }
+      };
+      const result = validator.validateResponse(response, testCase);
+      expect(result.valid).toBe(true);
+    });
 
   test('executes custom validation rule and handles its result', () => {
     const customFn = jest.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);

--- a/src/validator/ResponseValidator.ts
+++ b/src/validator/ResponseValidator.ts
@@ -167,26 +167,26 @@ export class ResponseValidator implements ResponseValidatorInterface {
    */
   private validateHasProperty(data: any, target: string): boolean {
     if (!target) return false;
-    
-    const parts = target.split('.');
+
+    const parts = this.parsePath(target);
     let current = data;
-    
+
     for (const part of parts) {
       if (current === null || current === undefined) {
         return false;
       }
-      
+
       if (typeof current !== 'object') {
         return false;
       }
-      
+
       if (!(part in current)) {
         return false;
       }
-      
-      current = current[part];
+
+      current = (current as any)[part];
     }
-    
+
     return true;
   }
 
@@ -215,22 +215,32 @@ export class ResponseValidator implements ResponseValidatorInterface {
    */
   private getValueByPath(data: any, path?: string): any {
     if (!path) return data;
-    
-    const parts = path.split('.');
+
+    const parts = this.parsePath(path);
     let current = data;
-    
+
     for (const part of parts) {
       if (current === null || current === undefined) {
         return undefined;
       }
-      
+
       if (typeof current !== 'object') {
         return undefined;
       }
-      
-      current = current[part];
+
+      current = (current as any)[part];
     }
-    
+
     return current;
+  }
+
+  /**
+   * Convert a path with optional bracket notation to an array of parts
+   */
+  private parsePath(path: string): Array<string | number> {
+    return path
+      .replace(/\[(\w+)\]/g, '.$1')
+      .split('.')
+      .filter(p => p !== '');
   }
 } 


### PR DESCRIPTION
## Summary
- parse bracket notation paths in validator
- update hasProperty and getValueByPath to use the new parsing
- test hasProperty with an array index path

## Testing
- `npm test` *(fails: jest not found)*