### PR TITLE
Improve npm packaging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,25 @@ The canonical test generator lives at `src/test-generator/TestGenerator.ts`.
 Older files such as `src/generator/TestGenerator.ts` have been removed to avoid
 confusion. All imports should reference the module under `src/test-generator/`.
 
+## Packaging and Distribution
+
+The project can be published as an npm package for easier installation.
+
+```bash
+# Compile TypeScript sources
+npm run build
+
+# Create a tarball of the package
+npm pack
+
+# Publish to npm (requires npm credentials)
+npm publish
+```
+
+Only the contents of the `dist` folder and essential documentation are included
+in the published package. The build step runs automatically when `npm publish`
+is executed.
+
 ## License
 
 This project is licensed under the [MIT](LICENSE) license.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "description": "Automated testing tool for MCP servers (WORK IN PROGRESS)",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "mcp-servers.json.example",
+    "README.md",
+    "LICENSE"
+  ],
   "bin": {
     "mcp-server-tester": "dist/index.js"
   },
@@ -11,7 +18,8 @@
     "start": "NODE_NO_WARNINGS=1 node dist/index.js",
     "dev": "NODE_NO_WARNINGS=1 ts-node src/index.ts",
     "test": "jest",
-    "lint": "eslint src --ext .ts"
+    "lint": "eslint src --ext .ts",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
- include build output in npm package
- run `npm run build` automatically before publishing
- document how to package and publish the project

## Testing
- `npm test` *(fails: jest not found)*